### PR TITLE
Configure global Memory of the World challenge on Meta-Wiki

### DIFF
--- a/config/config.meta-motw2025.yml
+++ b/config/config.meta-motw2025.yml
@@ -1,0 +1,5 @@
+_extends: sites/metawiki.yml
+name: Memory of the World Challenge 2025
+pages:
+    base: Memory_of_the_World_challenge_2025
+    default: Memory_of_the_World_challenge_2025/points

--- a/config/sites/metawiki.yml
+++ b/config/sites/metawiki.yml
@@ -1,0 +1,8 @@
+_extends: enwiki.yml
+homesite: meta.wikimedia.org
+othersites:
+    - '*.wikipedia.org'
+    - www.wikidata.org
+default_prefix: meta
+contestPages:
+    footer: ""

--- a/jobs.yaml
+++ b/jobs.yaml
@@ -129,3 +129,16 @@
   image: python3.11
   schedule: "54 23 * * *"
   emails: onfailure
+# meta-motw2025
+- name: meta-motw2025
+  command: ./jobs/run.sh meta-motw2025
+  image: python3.11
+  schedule: "7 * * * *"
+  emails: onfailure
+  mem: 2Gi
+- name: upload-plot-meta-motw2025
+  command: ./jobs/upload.sh meta-motw2025
+  image: python3.11
+  schedule: "37 23 * * *"
+  emails: onfailure
+  mem: 2Gi


### PR DESCRIPTION
## Summary
- Extend contest jobs to include the Meta-Wiki Memory of the World challenge 2025
- Introduce Meta-Wiki site configuration supporting edits across all Wikipedias and Wikidata
- Add contest configuration for Memory of the World Challenge 2025

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0b3215378832eb8951714a88e0265