### PR TITLE
Allow subdomain wildcards in othersites configuration

### DIFF
--- a/test/test_sites.py
+++ b/test/test_sites.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest.mock import patch
+
+from ukbot.sites import init_sites
+
+
+class DummySite:
+    def __init__(self, host, prefixes, **kwargs):
+        self.host = host
+        self.name = host
+        self.key = host
+        self.prefixes = prefixes
+        self.logged_in = True
+        self.interwikimap = {
+            'en': 'en.wikipedia.org',
+            'de': 'de.wikipedia.org',
+            'fr': 'fr.wikipedia.org',
+            'meta': 'meta.wikimedia.org',
+        }
+        self.pages = {}
+
+
+class TestInitSites(unittest.TestCase):
+    @patch('ukbot.sites.db_conn')
+    @patch('ukbot.sites.fetch_interwikimap')
+    @patch('ukbot.sites.Site', new=DummySite)
+    def test_othersites_wildcard(self, mock_fetch, mock_db_conn):
+        mock_fetch.return_value = {
+            'en': 'en.wikipedia.org',
+            'de': 'de.wikipedia.org',
+            'fr': 'fr.wikipedia.org',
+            'meta': 'meta.wikimedia.org',
+        }
+        config = {
+            'homesite': 'en.wikipedia.org',
+            'othersites': ['*.wikipedia.org']
+        }
+        manager, sql = init_sites(config)
+
+        self.assertIn('en.wikipedia.org', manager.sites)
+        self.assertIn('de.wikipedia.org', manager.sites)
+        self.assertIn('fr.wikipedia.org', manager.sites)
+        self.assertNotIn('meta.wikimedia.org', manager.sites)
+        self.assertNotIn('*.wikipedia.org', manager.sites)
+        mock_db_conn.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support wildcard host patterns in `othersites` config
- retrieve interwiki map from Wikimedia API for site initialization
- test wildcard site expansion using mocked API data

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ba0eb9dc832eaadf4cae663dae49