### PR TITLE
Speed up cross-wiki point calculation with globaluserinfo

### DIFF
--- a/ukbot/contest.py
+++ b/ukbot/contest.py
@@ -831,9 +831,12 @@ class Contest(object):
             user.add_contribs_from_db(self.sql, self.start, self.end, self.sites.sites)
 
             # Then fill in new contributions from wiki
+            edited_wikis = user.wikis_with_edits()
             for site in self.sites.sites.values():
 
                 # if host_filter is None or site.host == host_filter:
+                if edited_wikis is not None and site.dbname not in edited_wikis:
+                    continue
                 user.add_contribs_from_wiki(site, self.start, self.end, fulltext=True, **extraargs)
 
             # And update db

--- a/ukbot/site.py
+++ b/ukbot/site.py
@@ -36,7 +36,10 @@ class Site(mwclient.Site):
         logger.debug('Initializing site: %s', host)
         mwclient.Site.__init__(self, host, pool=session, **kwargs)
 
-        res = self.api('query', meta='siteinfo', siprop='magicwords|namespaces|namespacealiases|interwikimap')['query']
+        res = self.api('query', meta='siteinfo',
+                        siprop='general|magicwords|namespaces|namespacealiases|interwikimap')['query']
+
+        self.dbname = res.get('general', {}).get('dbname')
 
         self.file_prefixes = [res['namespaces']['6']['*'], res['namespaces']['6']['canonical']] \
             + [x['*'] for x in res['namespacealiases'] if x['id'] == 6]


### PR DESCRIPTION
## Summary
- Store wiki database names when initializing `Site`
- Use globaluserinfo to fetch wikis where a user has edits
- Skip fetching contributions from wikis the user hasn't edited

## Testing
- `PYTHONPATH=. pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0be1a1a7c832eb434e6b5fde40c7e