### PR TITLE
Add external link filtering capability

### DIFF
--- a/config/config.se.yml
+++ b/config/config.se.yml
@@ -101,6 +101,8 @@ templates:
         ignore: ignore
         sparql: sparql  # as in {{ ukb criterion | sparql }}
         query: query    # as in {{ ukb criterion | sparql | query=... }}
+        external_links: external_links
+        url: url
 pages:
     catignore: Käyttäjä:UKBot/cat-ignore
     base: Wikipedia:Elokuun_kuvitustalkoot/

--- a/config/sites/cawiki.yml
+++ b/config/sites/cawiki.yml
@@ -96,6 +96,11 @@ templates:
                 name: espai de noms
                 params:
                     site: lloc
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: lloc
             sparql:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:

--- a/config/sites/enwiki.yml
+++ b/config/sites/enwiki.yml
@@ -94,6 +94,11 @@ templates:
                 name: namespace
                 params:
                     site: site
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: site
             sparql:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:

--- a/config/sites/eswiki.yml
+++ b/config/sites/eswiki.yml
@@ -91,6 +91,11 @@ templates:
                 name: espacio de nombres
                 params:
                     site: site
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: site
             sparql:
                 name: sparql # as in {{ ukb criterion | sparql }}
                 params:

--- a/config/sites/euwiki.yml
+++ b/config/sites/euwiki.yml
@@ -94,6 +94,11 @@ templates:
                 name: izen-tartea
                 params:
                     site: site
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: site
             sparql:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:

--- a/config/sites/fiwiki.yml
+++ b/config/sites/fiwiki.yml
@@ -95,6 +95,11 @@ templates:
                 name: nimiavaruus
                 params:
                     site: site
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: site
             sparql:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:

--- a/config/sites/glwiki.yml
+++ b/config/sites/glwiki.yml
@@ -91,6 +91,11 @@ templates:
                 name: espazo de nomes
                 params:
                     site: site
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: site
             sparql:
                 name: sparql # as in {{ ukb criterion | sparql }}
                 params:

--- a/config/sites/nowiki.yml
+++ b/config/sites/nowiki.yml
@@ -101,6 +101,11 @@ templates:
                 name: navnerom
                 params:
                     site: nettsted
+            external_links:
+                name: external_links
+                params:
+                    url: url
+                    site: nettsted
             sparql:
                 name: sparql  # as in {{ ukb criterion | sparql }}
                 params:

--- a/test/test_rules.py
+++ b/test/test_rules.py
@@ -1,7 +1,7 @@
 # encoding=utf-8
 import re
 from datetime import datetime
-import mock
+from unittest import mock
 import json
 from unittest import TestCase
 

--- a/ukbot/contest.py
+++ b/ukbot/contest.py
@@ -20,7 +20,7 @@ from .rules import NewPageRule, ByteRule, WordRule, RefRule, ImageRule, Template
 from .common import _, STATE_ENDING, STATE_CLOSING, InvalidContestPage
 from .rules import rule_classes
 from .filters import CatFilter, TemplateFilter, NewPageFilter, ExistingPageFilter, ByteFilter, SparqlFilter, \
-    BackLinkFilter, ForwardLinkFilter, NamespaceFilter, PageFilter
+    BackLinkFilter, ExternalLinksFilter, ForwardLinkFilter, NamespaceFilter, PageFilter
 from .db import result_iterator
 from .user import User
 from .util import cleanup_input, unix_time, parse_infobox
@@ -96,6 +96,7 @@ class FilterTemplate(object):
             'category': CatFilter,
             'sparql': SparqlFilter,
             'backlink': BackLinkFilter,
+            'external_links': ExternalLinksFilter,
             'forwardlink': ForwardLinkFilter,
             'namespace': NamespaceFilter,
             'pages': PageFilter,


### PR DESCRIPTION
## Summary
- add `ExternalLinksFilter` to match pages containing specified external URLs
- register new filter and expose configuration keys
- cover external link filtering with a unit test

## Testing
- `pytest -q` *(fails: No module named 'faker', 'pytz', 'ukbot')*
- `PYTHONPATH=. pytest test/test_filters.py::TestExternalLinksFilter::test_filter -q` *(fails: No module named 'more_itertools')*

------
https://chatgpt.com/codex/tasks/task_e_68c683c82364832eadf120f4a521ae93